### PR TITLE
Kubevirt standalone additional features

### DIFF
--- a/KUBEVIRT.md
+++ b/KUBEVIRT.md
@@ -106,7 +106,7 @@ metadata:
   name: kubevirt-demo
   namespace: kcm-system
 spec:
-  template: kubevirt-standalone-cp-0-3-0
+  template: kubevirt-standalone-cp-0-3-1
   credential: kubevirt-cluster-identity-cred
   config:
     controlPlaneNumber: 1

--- a/charts/kubevirt-pp/templates/cluster-templates.yaml
+++ b/charts/kubevirt-pp/templates/cluster-templates.yaml
@@ -2,13 +2,13 @@
 apiVersion: k0rdent.mirantis.com/v1alpha1
 kind: ClusterTemplate
 metadata:
-  name: kubevirt-standalone-cp-0-3-0
+  name: kubevirt-standalone-cp-0-3-1
   namespace: {{ .Values.config.namespace | default .Release.Namespace | trunc 63 }}
 spec:
   helm:
     chartSpec:
       chart: kubevirt-standalone-cp
-      version: 0.3.0
+      version: 0.3.1
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/charts/kubevirt-standalone-cp/Chart.yaml
+++ b/charts/kubevirt-standalone-cp/Chart.yaml
@@ -3,7 +3,7 @@ name: kubevirt-standalone-cp
 description: |
   A KCM template to deploy a k0s cluster on KubeVirt with bootstrapped control plane nodes.
 type: application
-version: 0.3.0
+version: 0.3.1
 appVersion: "v1.31.8+k0s.0"
 annotations:
   cluster.x-k8s.io/provider: infrastructure-kubevirt, control-plane-k0sproject-k0smotron, bootstrap-k0sproject-k0smotron

--- a/charts/kubevirt-standalone-cp/templates/cloud-provider-clusterrole.yaml
+++ b/charts/kubevirt-standalone-cp/templates/cloud-provider-clusterrole.yaml
@@ -1,0 +1,11 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kccm-{{ .Values.cluster.namespace | default .Release.Namespace | trunc 63 }}-{{ .Release.Name }}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get

--- a/charts/kubevirt-standalone-cp/templates/cloud-provider-clusterrolebinding.yaml
+++ b/charts/kubevirt-standalone-cp/templates/cloud-provider-clusterrolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kccm-{{ .Values.cluster.namespace | default .Release.Namespace | trunc 63 }}-{{ .Release.Name }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kccm-{{ .Values.cluster.namespace | default .Release.Namespace | trunc 63 }}-{{ .Release.Name }}
+subjects:
+- kind: ServiceAccount
+  name: cloud-controller-manager-{{ .Release.Name }}
+  namespace: {{ .Values.cluster.namespace | default .Release.Namespace | trunc 63 }}

--- a/charts/kubevirt-standalone-cp/templates/cloud-provider-configmap.yaml
+++ b/charts/kubevirt-standalone-cp/templates/cloud-provider-configmap.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+data:
+  cloud-config: |
+    instancesV2:
+      enabled: true
+      zoneAndRegionEnabled: true
+    loadBalancer:
+      creationPollInterval: 5
+      creationPollTimeout: 60
+    namespace: {{ .Values.cluster.namespace | default .Release.Namespace | trunc 63 }}
+kind: ConfigMap
+metadata:
+  name: cloud-config-{{ .Release.Name }}
+  namespace: {{ .Values.cluster.namespace | default .Release.Namespace | trunc 63 }}

--- a/charts/kubevirt-standalone-cp/templates/cloud-provider-deployment.yaml
+++ b/charts/kubevirt-standalone-cp/templates/cloud-provider-deployment.yaml
@@ -1,0 +1,58 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    k8s-app: kubevirt-cloud-controller-manager-{{ .Release.Name }}
+  name: kubevirt-cloud-controller-manager-{{ .Release.Name }}
+  namespace: {{ .Values.cluster.namespace | default .Release.Namespace | trunc 63 }}
+spec:
+  replicas: {{ .Values.cloudControllerManager.replicas }}
+  selector:
+    matchLabels:
+      k8s-app: kubevirt-cloud-controller-manager-{{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        k8s-app: kubevirt-cloud-controller-manager-{{ .Release.Name }}
+    spec:
+      containers:
+      - args:
+        - --cloud-provider=kubevirt
+        - --cloud-config=/etc/cloud/cloud-config
+        - --kubeconfig=/etc/kubernetes/kubeconfig/value
+        - --authentication-skip-lookup=true
+        - --cluster-name={{ .Release.Name }}
+        command:
+        - /bin/kubevirt-cloud-controller-manager
+        image: {{ .Values.cloudControllerManager.repo }}/{{ .Values.cloudControllerManager.name }}:{{ .Values.cloudControllerManager.tag }}
+        imagePullPolicy: Always
+        name: kubevirt-cloud-controller-manager
+        resources:
+          requests:
+            cpu: 100m
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /etc/kubernetes/kubeconfig
+          name: kubeconfig
+          readOnly: true
+        - mountPath: /etc/cloud
+          name: cloud-config
+          readOnly: true
+      serviceAccountName: cloud-controller-manager-{{ .Release.Name }}
+      {{- if .Values.cloudControllerManager.topologySpreadConstraints }}
+      topologySpreadConstraints: {{ tpl (toYaml .Values.cloudControllerManager.topologySpreadConstraints) $ | nindent 6 }}
+      {{- end }}
+      tolerations:
+      - effect: NoSchedule
+        key: node.cloudprovider.kubernetes.io/uninitialized
+        value: "true"
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/control-plane
+      volumes:
+      - configMap:
+          name: cloud-config-{{ .Release.Name }}
+        name: cloud-config
+      - name: kubeconfig
+        secret:
+          secretName: {{ .Release.Name }}-kubeconfig

--- a/charts/kubevirt-standalone-cp/templates/cloud-provider-role.yaml
+++ b/charts/kubevirt-standalone-cp/templates/cloud-provider-role.yaml
@@ -1,0 +1,43 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: kccm-{{ .Release.Name }}
+  namespace: {{ .Values.cluster.namespace | default .Release.Namespace | trunc 63 }}
+rules:
+- apiGroups:
+  - kubevirt.io
+  resources:
+  - virtualmachines
+  verbs:
+  - get
+  - watch
+  - list
+- apiGroups:
+  - kubevirt.io
+  resources:
+  - virtualmachineinstances
+  verbs:
+  - get
+  - watch
+  - list
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - '*'
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get

--- a/charts/kubevirt-standalone-cp/templates/cloud-provider-rolebinding.yaml
+++ b/charts/kubevirt-standalone-cp/templates/cloud-provider-rolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: kccm-{{ .Release.Name }}
+  namespace: {{ .Values.cluster.namespace | default .Release.Namespace | trunc 63 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: kccm-{{ .Release.Name }}
+subjects:
+- kind: ServiceAccount
+  name: cloud-controller-manager-{{ .Release.Name }}

--- a/charts/kubevirt-standalone-cp/templates/cloud-provider-serviceaccount.yaml
+++ b/charts/kubevirt-standalone-cp/templates/cloud-provider-serviceaccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cloud-controller-manager-{{ .Release.Name }}
+  namespace: {{ .Values.cluster.namespace | default .Release.Namespace | trunc 63 }}

--- a/charts/kubevirt-standalone-cp/templates/cloud-provider-system-rolebinding.yaml
+++ b/charts/kubevirt-standalone-cp/templates/cloud-provider-system-rolebinding.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: kccm-{{ .Values.cluster.namespace | default .Release.Namespace | trunc 63 }}-{{ .Release.Name }}
+  namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: extension-apiserver-authentication-reader
+subjects:
+- kind: ServiceAccount
+  name: cloud-controller-manager-{{ .Release.Name }}
+  namespace: {{ .Values.cluster.namespace | default .Release.Namespace | trunc 63 }}

--- a/charts/kubevirt-standalone-cp/templates/k0scontrolplane.yaml
+++ b/charts/kubevirt-standalone-cp/templates/k0scontrolplane.yaml
@@ -13,6 +13,8 @@ spec:
     {{- end }}
     args:
       - --enable-worker
+      - --enable-cloud-provider
+      - --kubelet-extra-args="--cloud-provider=external"
       - --disable-components=konnectivity-server
     k0s:
       apiVersion: k0s.k0sproject.io/v1beta1

--- a/charts/kubevirt-standalone-cp/templates/k0sworkerconfigtemplate.yaml
+++ b/charts/kubevirt-standalone-cp/templates/k0sworkerconfigtemplate.yaml
@@ -7,6 +7,9 @@ spec:
   template:
     spec:
       version: {{ .Values.k0s.version }}
+      args:
+      - --enable-cloud-provider
+      - --kubelet-extra-args="--cloud-provider=external"
       preStartCommands:
       {{- with .Values.worker.preStartCommands }}
         {{- toYaml . | nindent 8 }}

--- a/charts/kubevirt-standalone-cp/templates/kubevirtmachinetemplate-controlplane.yaml
+++ b/charts/kubevirt-standalone-cp/templates/kubevirtmachinetemplate-controlplane.yaml
@@ -12,7 +12,7 @@ spec:
         metadata:
           namespace: {{ .Values.cluster.namespace | default .Release.Namespace | trunc 63 }}
         spec:
-          runStrategy: Always
+          runStrategy: {{ .Values.controlPlane.runStrategy }}
           template:
             spec:
               # https://doc.crds.dev/github.com/kubernetes-sigs/cluster-api-provider-kubevirt/infrastructure.cluster.x-k8s.io/KubevirtMachineTemplate/v1alpha1@v0.1.9#spec-template-spec-virtualMachineTemplate-spec-template

--- a/charts/kubevirt-standalone-cp/templates/kubevirtmachinetemplate-controlplane.yaml
+++ b/charts/kubevirt-standalone-cp/templates/kubevirtmachinetemplate-controlplane.yaml
@@ -23,6 +23,10 @@ spec:
                   interfaces:
                   - name: default
                     bridge: {}
+                  {{- range .Values.controlPlane.additionalNetworkInterfaces }}
+                  - name: {{ .name }}
+                    bridge: {}
+                  {{- end }}
                   disks:
                     - disk:
                         bus: virtio
@@ -34,6 +38,9 @@ spec:
               networks:
                 - name: default
                   pod: {}
+              {{- with .Values.controlPlane.additionalNetworkInterfaces }}
+                {{- toYaml . | nindent 16 }}
+              {{- end }}
               volumes:
                 - containerDisk:
                     image: {{ .Values.controlPlane.image }}

--- a/charts/kubevirt-standalone-cp/templates/kubevirtmachinetemplate-controlplane.yaml
+++ b/charts/kubevirt-standalone-cp/templates/kubevirtmachinetemplate-controlplane.yaml
@@ -28,9 +28,17 @@ spec:
                     bridge: {}
                   {{- end }}
                   disks:
+                  {{- if .Values.controlPlane.dataVolumes }}
+                  {{- range .Values.controlPlane.dataVolumes }}
+                    - disk:
+                        bus: virtio
+                      name: {{ .name }}
+                  {{- end }}
+                  {{- else }}
                     - disk:
                         bus: virtio
                       name: containervolume
+                  {{- end }}
                   networkInterfaceMultiqueue: true
                 memory:
                   guest: {{ .Values.controlPlane.memory }}
@@ -42,6 +50,37 @@ spec:
                 {{- toYaml . | nindent 16 }}
               {{- end }}
               volumes:
-                - containerDisk:
+                {{- if .Values.controlPlane.dataVolumes }}
+                {{- range .Values.controlPlane.dataVolumes }}
+                - name: {{ .name }}
+                  dataVolume:
+                    name: {{ .name }}
+                {{- end }}
+                {{- else }}
+                - name: containervolume
+                  containerDisk:
                     image: {{ .Values.controlPlane.image }}
-                  name: containervolume
+                {{- end }}
+          {{- if .Values.controlPlane.dataVolumes }}
+          dataVolumeTemplates:
+          {{- range .Values.controlPlane.dataVolumes }}
+          - apiVersion: cdi.kubevirt.io/v1beta1
+            kind: DataVolume
+            metadata:
+              name: {{ .name }}
+              annotations:
+                # https://github.com/kubevirt/containerized-data-importer/blob/main/doc/waitforfirstconsumer-storage-handling.md
+                cdi.kubevirt.io/storage.bind.immediate.requested: ""
+            spec:
+              pvc:
+                accessModes:
+                - {{ .accessModes }}
+                resources:
+                  requests:
+                    storage: {{ .storage }}
+                volumeMode: {{ .volumeMode }}
+                storageClassName: {{ .storageClassName }}
+              source:
+                {{- toYaml .source | nindent 16 }}
+          {{- end }}
+          {{- end }}

--- a/charts/kubevirt-standalone-cp/templates/kubevirtmachinetemplate-controlplane.yaml
+++ b/charts/kubevirt-standalone-cp/templates/kubevirtmachinetemplate-controlplane.yaml
@@ -20,6 +20,9 @@ spec:
                 cpu:
                   cores: {{ .Values.controlPlane.cpus }}
                 devices:
+                  interfaces:
+                  - name: default
+                    bridge: {}
                   disks:
                     - disk:
                         bus: virtio
@@ -28,6 +31,9 @@ spec:
                 memory:
                   guest: {{ .Values.controlPlane.memory }}
               evictionStrategy: External
+              networks:
+                - name: default
+                  pod: {}
               volumes:
                 - containerDisk:
                     image: {{ .Values.controlPlane.image }}

--- a/charts/kubevirt-standalone-cp/templates/kubevirtmachinetemplate-worker.yaml
+++ b/charts/kubevirt-standalone-cp/templates/kubevirtmachinetemplate-worker.yaml
@@ -12,7 +12,7 @@ spec:
         metadata:
           namespace: {{ .Values.cluster.namespace | default .Release.Namespace | trunc 63 }}
         spec:
-          runStrategy: Always
+          runStrategy: {{ .Values.worker.runStrategy }}
           template:
             spec:
               # https://doc.crds.dev/github.com/kubernetes-sigs/cluster-api-provider-kubevirt/infrastructure.cluster.x-k8s.io/KubevirtMachineTemplate/v1alpha1@v0.1.9#spec-template-spec-virtualMachineTemplate-spec-template

--- a/charts/kubevirt-standalone-cp/templates/kubevirtmachinetemplate-worker.yaml
+++ b/charts/kubevirt-standalone-cp/templates/kubevirtmachinetemplate-worker.yaml
@@ -20,6 +20,9 @@ spec:
                 cpu:
                   cores: {{ .Values.worker.cpus }}
                 devices:
+                  interfaces:
+                  - name: default
+                    bridge: {}
                   disks:
                     - disk:
                         bus: virtio
@@ -28,6 +31,9 @@ spec:
                 memory:
                   guest: {{ .Values.worker.memory }}
               evictionStrategy: External
+              networks:
+                - name: default
+                  pod: {}
               volumes:
                 - containerDisk:
                     image: {{ .Values.worker.image }}

--- a/charts/kubevirt-standalone-cp/templates/kubevirtmachinetemplate-worker.yaml
+++ b/charts/kubevirt-standalone-cp/templates/kubevirtmachinetemplate-worker.yaml
@@ -28,9 +28,17 @@ spec:
                     bridge: {}
                   {{- end }}
                   disks:
+                  {{- if .Values.worker.dataVolumes }}
+                  {{- range .Values.worker.dataVolumes }}
+                    - disk:
+                        bus: virtio
+                      name: {{ .name }}
+                  {{- end }}
+                  {{- else }}
                     - disk:
                         bus: virtio
                       name: containervolume
+                  {{- end }}
                   networkInterfaceMultiqueue: true
                 memory:
                   guest: {{ .Values.worker.memory }}
@@ -42,6 +50,37 @@ spec:
                 {{- toYaml . | nindent 16 }}
               {{- end }}
               volumes:
-                - containerDisk:
+                {{- if .Values.worker.dataVolumes }}
+                {{- range .Values.worker.dataVolumes }}
+                - name: {{ .name }}
+                  dataVolume:
+                    name: {{ .name }}
+                {{- end }}
+                {{- else }}
+                - name: containervolume
+                  containerDisk:
                     image: {{ .Values.worker.image }}
-                  name: containervolume
+                {{- end }}
+          {{- if .Values.worker.dataVolumes }}
+          dataVolumeTemplates:
+          {{- range .Values.worker.dataVolumes }}
+          - apiVersion: cdi.kubevirt.io/v1beta1
+            kind: DataVolume
+            metadata:
+              name: {{ .name }}
+              annotations:
+                # https://github.com/kubevirt/containerized-data-importer/blob/main/doc/waitforfirstconsumer-storage-handling.md
+                cdi.kubevirt.io/storage.bind.immediate.requested: ""
+            spec:
+              pvc:
+                accessModes:
+                - {{ .accessModes }}
+                resources:
+                  requests:
+                    storage: {{ .storage }}
+                volumeMode: {{ .volumeMode }}
+                storageClassName: {{ .storageClassName }}
+              source:
+                {{- toYaml .source | nindent 16 }}
+          {{- end }}
+          {{- end }}

--- a/charts/kubevirt-standalone-cp/templates/kubevirtmachinetemplate-worker.yaml
+++ b/charts/kubevirt-standalone-cp/templates/kubevirtmachinetemplate-worker.yaml
@@ -23,6 +23,10 @@ spec:
                   interfaces:
                   - name: default
                     bridge: {}
+                  {{- range .Values.worker.additionalNetworkInterfaces }}
+                  - name: {{ .name }}
+                    bridge: {}
+                  {{- end }}
                   disks:
                     - disk:
                         bus: virtio
@@ -34,6 +38,9 @@ spec:
               networks:
                 - name: default
                   pod: {}
+              {{- with .Values.worker.additionalNetworkInterfaces }}
+                {{- toYaml . | nindent 16 }}
+              {{- end }}
               volumes:
                 - containerDisk:
                     image: {{ .Values.worker.image }}

--- a/charts/kubevirt-standalone-cp/templates/machinehealthcheck.yaml
+++ b/charts/kubevirt-standalone-cp/templates/machinehealthcheck.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.machineHealthCheck.enabled }}
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachineHealthCheck
+metadata:
+  name: {{ include "machinedeployment.name" . }}
+  namespace: {{ .Values.cluster.namespace | default .Release.Namespace | trunc 63 }}
+spec:
+  clusterName: {{ include "cluster.name" . }}
+  selector:
+    matchLabels:
+      cluster.x-k8s.io/deployment-name: {{ include "machinedeployment.name" . }}
+  unhealthyConditions:
+    - type: Ready
+      status: "False"
+      timeout: "300s"
+    - type: Ready
+      status: "Unknown"
+      timeout: "300s"
+  maxUnhealthy: "{{ .Values.machineHealthCheck.maxUnhealthy }}"
+  nodeStartupTimeout: "10m"
+{{- end }}

--- a/charts/kubevirt-standalone-cp/values.yaml
+++ b/charts/kubevirt-standalone-cp/values.yaml
@@ -25,6 +25,7 @@ clusterAnnotations: {} # @schema description: Annotations to apply to the cluste
 
 # KubeVirt machines parameters
 controlPlane: # @schema description: Control plane parameters; type: object
+  runStrategy: Always
   cpus: 2 # @schema description: Number of CPUs allocated to control plane nodes; type: integer; minimum: 1
   memory: "4Gi" # @schema description: Memory allocated to control plane nodes; type: string
   bootstrapCheckStrategy: none # @schema description: Strategy for bootstrap checks; type: string; enum: [none, ssh]
@@ -56,6 +57,7 @@ controlPlane: # @schema description: Control plane parameters; type: object
     - systemctl enable --now qemu-guest-agent
 
 worker: # @schema description: Worker parameters; type: object
+  runStrategy: Always
   cpus: 2 # @schema description: Number of CPUs allocated to worker nodes; type: integer; minimum: 1
   memory: "4Gi" # @schema description: Memory allocated to worker nodes; type: string
   bootstrapCheckStrategy: none # @schema description: Strategy for bootstrap checks; type: string; enum: [none, ssh]

--- a/charts/kubevirt-standalone-cp/values.yaml
+++ b/charts/kubevirt-standalone-cp/values.yaml
@@ -55,3 +55,18 @@ k0s: # @schema description: K0s parameters; type: object
     repository: "" # @schema description: Container image repository to use; type: string
   telemetry: # @schema description: Telemetry configuration; type: object
     enabled: false # @schema description: Whether to enable telemetry; type: boolean
+
+cloudControllerManager:
+  replicas: 1
+  repo: quay.io/kubevirt
+  name: kubevirt-cloud-controller-manager
+  tag: v0.5.1
+  topologySpreadConstraints: []
+#    - labelSelector:
+#        matchLabels:
+#          k8s-app: kubevirt-cloud-controller-manager-{{ .Release.Name }}
+#        matchLabelKeys:
+#          - pod-template-hash
+#        topologyKey: topology.kubernetes.io/zone
+#        maxSkew: 1
+#        whenUnsatisfiable: DoNotSchedule

--- a/charts/kubevirt-standalone-cp/values.yaml
+++ b/charts/kubevirt-standalone-cp/values.yaml
@@ -8,9 +8,9 @@ workersNumber: 1 # @schema description: The number of the worker nodes; type: nu
 clusterIdentity: # @schema description: The KubeVirt Service Account credentials secret reference, auto-populated; type: object
   name: "" # @schema description: The KubeVirt Service Account credentials secret name, auto-populated; type: string
 
-cluster: # @schema description: Basic cluster information; type: object
-  name: "" # @schema description: The name of the cluster; type: string
-  namespace: "default" # @schema description: The namespace where cluster resources will be created; type: string
+cluster: {} # @schema description: Basic cluster information; type: object
+ # name: "" # @schema description: The name of the cluster; type: string
+ # namespace: "default" # @schema description: The namespace where cluster resources will be created; type: string
 
 clusterNetwork: # @schema description: The cluster network configuration; type: object
   pods: # @schema description: The network ranges from which Pod networks are allocated; type: object

--- a/charts/kubevirt-standalone-cp/values.yaml
+++ b/charts/kubevirt-standalone-cp/values.yaml
@@ -70,3 +70,7 @@ cloudControllerManager:
 #        topologyKey: topology.kubernetes.io/zone
 #        maxSkew: 1
 #        whenUnsatisfiable: DoNotSchedule
+
+machineHealthCheck:
+  enabled: false
+  maxUnhealthy: 40%

--- a/charts/kubevirt-standalone-cp/values.yaml
+++ b/charts/kubevirt-standalone-cp/values.yaml
@@ -29,6 +29,10 @@ controlPlane: # @schema description: Control plane parameters; type: object
   memory: "4Gi" # @schema description: Memory allocated to control plane nodes; type: string
   bootstrapCheckStrategy: none # @schema description: Strategy for bootstrap checks; type: string; enum: [none, ssh]
   image: ghcr.io/k0rdent-oot/kubevirt-container-disk:debian-latest # @schema description: Container disk image for control plane nodes; type: string
+  additionalNetworkInterfaces: []
+  #  - name: bridge-net
+  #    multus:
+  #      networkName: bridge-1560
   preStartCommands: # @schema description: Commands to run before starting K0s service; type: array; items: string
     - apt update
     - env DEBIAN_FRONTEND=noninteractive apt -y install qemu-guest-agent
@@ -39,6 +43,10 @@ worker: # @schema description: Worker parameters; type: object
   memory: "4Gi" # @schema description: Memory allocated to worker nodes; type: string
   bootstrapCheckStrategy: none # @schema description: Strategy for bootstrap checks; type: string; enum: [none, ssh]
   image: ghcr.io/k0rdent-oot/kubevirt-container-disk:debian-latest # @schema description: Container disk image for worker nodes; type: string
+  additionalNetworkInterfaces: []
+  #  - name: bridge-net
+  #    multus:
+  #      networkName: bridge-1560
   preStartCommands: # @schema description: Commands to run before starting K0s service; type: array; items: string
     - apt update
     - env DEBIAN_FRONTEND=noninteractive apt -y install qemu-guest-agent

--- a/charts/kubevirt-standalone-cp/values.yaml
+++ b/charts/kubevirt-standalone-cp/values.yaml
@@ -33,6 +33,23 @@ controlPlane: # @schema description: Control plane parameters; type: object
   #  - name: bridge-net
   #    multus:
   #      networkName: bridge-1560
+  dataVolumes: []
+  #  - name: root
+  #    accessModes: ReadWriteMany
+  #    storage: 50Gi
+  #    volumeMode: Block
+  #    storageClassName: block-pool
+  #    source:
+  #      snapshot:
+  #        namespace: kcm-system
+  #        name: goldenimage-ubuntu2204
+  #  - name: data
+  #    accessModes: ReadWriteMany
+  #    storage: 1Gi
+  #    volumeMode: Block
+  #    storageClassName: block-pool
+  #    source:
+  #      blank: {}
   preStartCommands: # @schema description: Commands to run before starting K0s service; type: array; items: string
     - apt update
     - env DEBIAN_FRONTEND=noninteractive apt -y install qemu-guest-agent
@@ -47,6 +64,23 @@ worker: # @schema description: Worker parameters; type: object
   #  - name: bridge-net
   #    multus:
   #      networkName: bridge-1560
+  dataVolumes: []
+  #  - name: root
+  #    accessModes: ReadWriteMany
+  #    storage: 50Gi
+  #    volumeMode: Block
+  #    storageClassName: block-pool
+  #    source:
+  #      snapshot:
+  #        namespace: kcm-system
+  #        name: goldenimage-ubuntu2204
+  #  - name: data
+  #    accessModes: ReadWriteMany
+  #    storage: 1Gi
+  #    volumeMode: Block
+  #    storageClassName: block-pool
+  #    source:
+  #      blank: {}
   preStartCommands: # @schema description: Commands to run before starting K0s service; type: array; items: string
     - apt update
     - env DEBIAN_FRONTEND=noninteractive apt -y install qemu-guest-agent


### PR DESCRIPTION
This PR adds some features that are essential for the POC : 

- deploys kubevirt cloud controller manager (enabled by default, can't be disabled)
- adds machinehealthcheck (disabled by default)
- add support for configuring additional network interfaces using multus (disabled by default)
- add support for using a list of DataVolumes for root disk and additional disks (containerImage by default)
- add support for configuring runStrategy (still "Always" by default like before)

I made all these features opt-in (except kccm that can't be disabled), so that there is no change compared to template 0-3-0 when you use the ClusterDeployment example from the doc.

Also some fixes : 
- removing default namespace in values. Will use "release namespace" by default, or cluster.namespace if specified in Values
- explicitly configuring pod network interface in bridge mode