### PR TITLE
adding kubevirt-csi-driver

### DIFF
--- a/charts/kubevirt-standalone-cp/Chart.yaml
+++ b/charts/kubevirt-standalone-cp/Chart.yaml
@@ -4,7 +4,7 @@ description: |
   A KCM template to deploy a k0s cluster on KubeVirt with bootstrapped control plane nodes.
 type: application
 version: 0.3.3
-appVersion: "v1.31.8+k0s.0"
+appVersion: "v1.31.9+k0s.0"
 annotations:
   cluster.x-k8s.io/provider: infrastructure-kubevirt, control-plane-k0sproject-k0smotron, bootstrap-k0sproject-k0smotron
   k0rdent.mirantis.com/type: deployment

--- a/charts/kubevirt-standalone-cp/Chart.yaml
+++ b/charts/kubevirt-standalone-cp/Chart.yaml
@@ -3,7 +3,7 @@ name: kubevirt-standalone-cp
 description: |
   A KCM template to deploy a k0s cluster on KubeVirt with bootstrapped control plane nodes.
 type: application
-version: 0.3.2
+version: 0.3.3
 appVersion: "v1.31.8+k0s.0"
 annotations:
   cluster.x-k8s.io/provider: infrastructure-kubevirt, control-plane-k0sproject-k0smotron, bootstrap-k0sproject-k0smotron

--- a/charts/kubevirt-standalone-cp/templates/kubevirt-csidriver-clusterrole.yaml
+++ b/charts/kubevirt-standalone-cp/templates/kubevirt-csidriver-clusterrole.yaml
@@ -1,0 +1,10 @@
+{{- if .Values.kubevirtCsiDriver.enabled }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kubevirt-csi-cluster-{{ .Release.Name }}
+rules:
+- apiGroups: [""]
+  resources: ["persistentvolumes"]
+  verbs: ["get"]
+{{- end }}

--- a/charts/kubevirt-standalone-cp/templates/kubevirt-csidriver-clusterrolebinding.yaml
+++ b/charts/kubevirt-standalone-cp/templates/kubevirt-csidriver-clusterrolebinding.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.kubevirtCsiDriver.enabled }}
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: kubevirt-csi-cluster-binding-{{ .Release.Name }}
+roleRef:
+  kind: ClusterRole
+  name: kubevirt-csi-cluster-{{ .Release.Name }}
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+- kind: ServiceAccount
+  name: kubevirt-csi-{{ .Release.Name }}
+  namespace: {{ .Values.cluster.namespace | default .Release.Namespace | trunc 63 }}
+{{- end }}

--- a/charts/kubevirt-standalone-cp/templates/kubevirt-csidriver-configmap.yaml
+++ b/charts/kubevirt-standalone-cp/templates/kubevirt-csidriver-configmap.yaml
@@ -1,0 +1,10 @@
+{{- if .Values.kubevirtCsiDriver.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: driver-config-{{ .Release.Name }}
+  namespace: {{ .Values.cluster.namespace | default .Release.Namespace | trunc 63 }}
+data:
+  infraClusterNamespace: {{ .Values.cluster.namespace | default .Release.Namespace | trunc 63 }}
+  infraClusterLabels: csi-driver/cluster={{ .Release.Name }}
+{{- end }}

--- a/charts/kubevirt-standalone-cp/templates/kubevirt-csidriver-deployment.yaml
+++ b/charts/kubevirt-standalone-cp/templates/kubevirt-csidriver-deployment.yaml
@@ -1,0 +1,180 @@
+{{- if .Values.kubevirtCsiDriver.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: kubevirt-csi-driver-{{ .Release.Name }}
+  name: kubevirt-csi-controller-{{ .Release.Name }}
+  namespace: {{ .Values.cluster.namespace | default .Release.Namespace | trunc 63 }}
+spec:
+  replicas: {{ .Values.kubevirtCsiDriver.replicas }}
+  selector:
+    matchLabels:
+      app: kubevirt-csi-driver-{{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app: kubevirt-csi-driver-{{ .Release.Name }}
+    spec:
+      containers:
+      - args:
+        - --endpoint=$(CSI_ENDPOINT)
+        - --infra-cluster-namespace=$(INFRACLUSTER_NAMESPACE)
+        - --infra-cluster-labels=$(INFRACLUSTER_LABELS)
+        - --tenant-cluster-kubeconfig=/var/run/secrets/tenantcluster/value
+        - --run-node-service=false
+        - --run-controller-service=true
+        - --v=5
+        env:
+        - name: CSI_ENDPOINT
+          value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
+        - name: KUBE_NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: INFRACLUSTER_NAMESPACE
+          valueFrom:
+            configMapKeyRef:
+              key: infraClusterNamespace
+              name: driver-config-{{ .Release.Name }}
+        - name: INFRACLUSTER_LABELS
+          valueFrom:
+            configMapKeyRef:
+              key: infraClusterLabels
+              name: driver-config-{{ .Release.Name }}
+        - name: INFRA_STORAGE_CLASS_ENFORCEMENT
+          valueFrom:
+            configMapKeyRef:
+              key: infraStorageClassEnforcement
+              name: driver-config-{{ .Release.Name }}
+              optional: true
+        image: {{ .Values.kubevirtCsiDriver.csiDriver.repo }}/{{ .Values.kubevirtCsiDriver.csiDriver.name }}:{{ .Values.kubevirtCsiDriver.csiDriver.tag }}
+        imagePullPolicy: Always
+        name: csi-driver
+        ports:
+        - containerPort: 10301
+          name: healthz
+          protocol: TCP
+        resources:
+          requests:
+            cpu: 10m
+            memory: 50Mi
+        volumeMounts:
+        - mountPath: /var/lib/csi/sockets/pluginproxy/
+          name: socket-dir
+        - mountPath: /var/run/secrets/tenantcluster
+          name: tenantcluster
+      - args:
+        - --csi-address=$(ADDRESS)
+        - --default-fstype=ext4
+        - --kubeconfig=/var/run/secrets/tenantcluster/value
+        - --v=5
+        - --timeout=3m
+        - --retry-interval-max=1m
+        env:
+        - name: ADDRESS
+          value: /var/lib/csi/sockets/pluginproxy/csi.sock
+        image: {{ .Values.kubevirtCsiDriver.csiProvisioner.repo }}/{{ .Values.kubevirtCsiDriver.csiProvisioner.name }}:{{ .Values.kubevirtCsiDriver.csiProvisioner.tag }}
+        name: csi-provisioner
+        volumeMounts:
+        - mountPath: /var/lib/csi/sockets/pluginproxy/
+          name: socket-dir
+        - mountPath: /var/run/secrets/tenantcluster
+          name: tenantcluster
+      - args:
+        - --csi-address=$(ADDRESS)
+        - --kubeconfig=/var/run/secrets/tenantcluster/value
+        - --v=5
+        - --timeout=3m
+        - --retry-interval-max=1m
+        env:
+        - name: ADDRESS
+          value: /var/lib/csi/sockets/pluginproxy/csi.sock
+        image: {{ .Values.kubevirtCsiDriver.csiAttacher.repo }}/{{ .Values.kubevirtCsiDriver.csiAttacher.name }}:{{ .Values.kubevirtCsiDriver.csiAttacher.tag }}
+        name: csi-attacher
+        resources:
+          requests:
+            cpu: 10m
+            memory: 50Mi
+        volumeMounts:
+        - mountPath: /var/lib/csi/sockets/pluginproxy/
+          name: socket-dir
+        - mountPath: /var/run/secrets/tenantcluster
+          name: tenantcluster
+      - args:
+        - --csi-address=/csi/csi.sock
+        - --probe-timeout=3s
+        - --health-port=10301
+        image: {{ .Values.kubevirtCsiDriver.csiLivenessProbe.repo }}/{{ .Values.kubevirtCsiDriver.csiLivenessProbe.name }}:{{ .Values.kubevirtCsiDriver.csiLivenessProbe.tag }}
+        name: csi-liveness-probe
+        resources:
+          requests:
+            cpu: 10m
+            memory: 50Mi
+        volumeMounts:
+        - mountPath: /csi
+          name: socket-dir
+        - mountPath: /var/run/secrets/tenantcluster
+          name: tenantcluster
+      - args:
+        - --v=5
+        - --csi-address=/csi/csi.sock
+        - --kubeconfig=/var/run/secrets/tenantcluster/value
+        - --timeout=3m
+        image: {{ .Values.kubevirtCsiDriver.csiSnapshotter.repo }}/{{ .Values.kubevirtCsiDriver.csiSnapshotter.name }}:{{ .Values.kubevirtCsiDriver.csiSnapshotter.tag }}
+        imagePullPolicy: IfNotPresent
+        name: csi-snapshotter
+        resources:
+          requests:
+            cpu: 10m
+            memory: 20Mi
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /csi
+          name: socket-dir
+        - mountPath: /var/run/secrets/tenantcluster
+          name: tenantcluster
+      - args:
+        - -csi-address=/csi/csi.sock
+        - -kubeconfig=/var/run/secrets/tenantcluster/value
+        - -v=5
+        - -timeout=3m
+        - -handle-volume-inuse-error=false
+        image: {{ .Values.kubevirtCsiDriver.csiResizer.repo }}/{{ .Values.kubevirtCsiDriver.csiResizer.name }}:{{ .Values.kubevirtCsiDriver.csiResizer.tag }}
+        name: csi-resizer
+        resources:
+          requests:
+            cpu: 10m
+            memory: 20Mi
+        securityContext:
+          capabilities:
+            drop:
+            - ALL
+        volumeMounts:
+        - mountPath: /csi
+          name: socket-dir
+        - mountPath: /var/run/secrets/tenantcluster
+          name: tenantcluster
+      enableServiceLinks: false
+      {{- if .Values.kubevirtCsiDriver.nodeSelector }}
+      nodeSelector: {{ toYaml .Values.kubevirtCsiDriver.nodeSelector | nindent 8 }}
+      {{- end }}
+      priorityClassName: system-cluster-critical
+      serviceAccount: kubevirt-csi-{{ .Release.Name }}
+      tolerations:
+      - key: CriticalAddonsOnly
+        operator: Exists
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/master
+        operator: Exists
+      {{- if .Values.kubevirtCsiDriver.topologySpreadConstraints }}
+      topologySpreadConstraints: {{ tpl (toYaml .Values.kubevirtCsiDriver.topologySpreadConstraints) $ | nindent 6 }}
+      {{- end }}
+      volumes:
+      - emptyDir: {}
+        name: socket-dir
+      - name: tenantcluster
+        secret:
+          secretName: {{ .Release.Name }}-kubeconfig
+{{- end }}

--- a/charts/kubevirt-standalone-cp/templates/kubevirt-csidriver-role.yaml
+++ b/charts/kubevirt-standalone-cp/templates/kubevirt-csidriver-role.yaml
@@ -1,0 +1,26 @@
+{{- if .Values.kubevirtCsiDriver.enabled }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: kubevirt-csi-{{ .Release.Name }}
+  namespace: {{ .Values.cluster.namespace | default .Release.Namespace | trunc 63 }}
+rules:
+- apiGroups: ["cdi.kubevirt.io"]
+  resources: ["datavolumes"]
+  verbs: ["get", "create", "delete"]
+- apiGroups: ["kubevirt.io"]
+  resources: ["virtualmachineinstances", "virtualmachines"]
+  verbs: ["list", "get"]
+- apiGroups: ["subresources.kubevirt.io"]
+  resources: ["virtualmachines/addvolume", "virtualmachines/removevolume"]
+  verbs: ["update"]
+- apiGroups: ["subresources.kubevirt.io"]
+  resources: ["virtualmachineinstances/addvolume", "virtualmachineinstances/removevolume"]
+  verbs: ["update"]
+- apiGroups: ["snapshot.storage.k8s.io"]
+  resources: ["volumesnapshots"]
+  verbs: ["get", "create", "delete"]
+- apiGroups: [""]
+  resources: ["persistentvolumeclaims"]
+  verbs: ["get", "patch"]
+{{- end }}

--- a/charts/kubevirt-standalone-cp/templates/kubevirt-csidriver-rolebinding.yaml
+++ b/charts/kubevirt-standalone-cp/templates/kubevirt-csidriver-rolebinding.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.kubevirtCsiDriver.enabled }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: kubevirt-csi-{{ .Release.Name }}
+  namespace: {{ .Values.cluster.namespace | default .Release.Namespace | trunc 63 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: kubevirt-csi-{{ .Release.Name }}
+subjects:
+- kind: ServiceAccount
+  name: kubevirt-csi-{{ .Release.Name }}
+{{- end }}

--- a/charts/kubevirt-standalone-cp/templates/kubevirt-csidriver-serviceaccount.yaml
+++ b/charts/kubevirt-standalone-cp/templates/kubevirt-csidriver-serviceaccount.yaml
@@ -1,0 +1,7 @@
+{{- if .Values.kubevirtCsiDriver.enabled }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kubevirt-csi-{{ .Release.Name }}
+  namespace: {{ .Values.cluster.namespace | default .Release.Namespace | trunc 63 }}
+{{- end }}

--- a/charts/kubevirt-standalone-cp/values.yaml
+++ b/charts/kubevirt-standalone-cp/values.yaml
@@ -129,6 +129,45 @@ cloudControllerManager:
 #        maxSkew: 1
 #        whenUnsatisfiable: DoNotSchedule
 
+kubevirtCsiDriver:
+  enabled: false
+  replicas: 1
+  csiDriver:
+    repo: quay.io/kubevirt
+    name: kubevirt-csi-driver
+    tag: latest
+  csiProvisioner:
+    repo: quay.io/openshift
+    name: origin-csi-external-provisioner
+    tag: latest
+  csiAttacher:
+    repo: quay.io/openshift
+    name: origin-csi-external-attacher
+    tag: latest
+  csiLivenessProbe:
+    repo: quay.io/openshift
+    name: origin-csi-livenessprobe
+    tag: latest
+  csiSnapshotter:
+    repo: k8s.gcr.io/sig-storage
+    name: csi-snapshotter
+    tag: v4.2.1
+  csiResizer:
+    repo: registry.k8s.io/sig-storage
+    name: csi-resizer
+    tag: v1.13.1
+  nodeSelector:
+    node-role.kubernetes.io/control-plane: "true"
+  topologySpreadConstraints: []
+#    - labelSelector:
+#        matchLabels:
+#          k8s-app: kubevirt-csi-driver-{{ .Release.Name }}
+#        matchLabelKeys:
+#          - pod-template-hash
+#        topologyKey: topology.kubernetes.io/zone
+#        maxSkew: 1
+#        whenUnsatisfiable: DoNotSchedule
+
 machineHealthCheck:
   enabled: false
   maxUnhealthy: 40%

--- a/charts/kubevirt-standalone-cp/values.yaml
+++ b/charts/kubevirt-standalone-cp/values.yaml
@@ -104,7 +104,7 @@ worker: # @schema description: Worker parameters; type: object
 
 # K0s parameters
 k0s: # @schema description: K0s parameters; type: object
-  version: v1.31.8+k0s.0 # @schema description: K0s version; type: string
+  version: v1.31.9+k0s.0 # @schema description: K0s version; type: string
   api: # @schema description: Kubernetes API server parameters; type: object; additionalProperties: object
     extraArgs: {} # @schema description: Map of key-values (strings) for any extra arguments to pass down to Kubernetes api-server process; type: object; additionalProperties: true
   network: # @schema description: Network configuration for K0s; type: object


### PR DESCRIPTION
Enable the deployment of the mothership part of kubevirt-csi-driver.
Another part must be deployed on the child cluster, and will be deployed as a ServiceTemplate